### PR TITLE
Technical/Update application dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2020-10-23
+
+### Changed
+
+- Updated application dependencies (truemail core)
+- Updated application version
+
 ## [0.2.4] - 2020-08-06
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby(File.read(File.join(File.dirname(__FILE__), '.ruby-version')).strip[/-(.+)/
 gem 'dry-struct', '~> 1.3'
 gem 'rack', '~> 2.2', '>= 2.2.3'
 gem 'thin', '~> 1.7', '>= 1.7.2'
-gem 'truemail', '~> 1.8'
+gem 'truemail', '~> 2.0', '>= 2.0.1'
 
 group :development, :test do
   gem 'pry-byebug', '~> 3.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (1.0.1)
-    truemail (1.8.0)
+    truemail (2.0.1)
       simpleidn (~> 0.1.1)
     unf (0.1.4)
       unf_ext
@@ -146,7 +146,7 @@ DEPENDENCIES
   rubocop-rspec (~> 1.42)
   simplecov (~> 0.17.1)
   thin (~> 1.7, >= 1.7.2)
-  truemail (~> 1.8)
+  truemail (~> 2.0, >= 2.0.1)
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/app/truemail_server/version.rb
+++ b/app/truemail_server/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TruemailServer
-  VERSION = '0.2.4'
+  VERSION = '0.2.5'
 end


### PR DESCRIPTION
Following the fix of the critical bug: https://github.com/truemail-rb/truemail/issues/97

- [x] Updated Truemail gem to latest version (2.0.1)
- [x] Updated application version