### PR TITLE
Feature/Add ability to use SMTP fail fast flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2020-12-11
+
+- Ability to use [SMTP fail fast flow](https://truemail-rb.org/truemail-gem/#/validations-layers?id=smtp-fail-fast-enabled)
+
+### Changed
+
+- Updated application dependencies
+- Updated application documentation
+- Updated application version
+
 ## [0.2.7] - 2020-12-07
 
 ### Changed
@@ -47,7 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-- Ability to use [not RFC MX lookup flow](https://github.com/truemail-rb/truemail#not-rfc-mx-lookup-flow)
+- Ability to use [not RFC MX lookup flow](https://truemail-rb.org/truemail-gem/#/validations-layers?id=not-rfc-mx-lookup-flow)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Before run application you must configure it first. List of available env vars n
 | `WHITELIST_VALIDATION` | `true` | - | With this option Truemail will validate email which [contains whitelisted domain only](https://truemail-rb.org/truemail-gem/#/validations-layers?id=whitelist-validation-case), i.e. if domain whitelisted, validation will passed to Regex, MX or SMTP validators. Validation of email which not contains whitelisted domain always will return `false`. It is equal `false` by default. |
 | `BLACKLISTED_DOMAINS` | `somedomain2.com` | - | Validation of email which [contains blacklisted domain](https://truemail-rb.org/truemail-gem/#/validations-layers?id=blacklist-case) always will return `false`. Other validations will not processed even if it was defined in `VALIDATION_TYPE_FOR`. Accepts one ore more values separated by commas. |
 | `NOT_RFC_MX_LOOKUP_FLOW` | `true` | - | This option will provide to use not RFC MX lookup flow. It means that MX and Null MX records will be cheked on the DNS validation layer only. By default [this option is disabled](https://truemail-rb.org/truemail-gem/#/validations-layers?id=not-rfc-mx-lookup-flow). |
+| `SMTP_FAIL_FAST` | `true` | - | This option will provide to use SMTP fail fast behaviour. When [smtp_fail_fast is enabled](https://truemail-rb.org/truemail-gem/#/validations-layers?id=smtp-fail-fast-enabled) it means that truemail ends smtp validation session after first attempt on the first mx server in any fail cases (network connection/timeout error, smtp validation error). By default this option is disabled, available for SMTP validation only. |
 | `SMTP_SAFE_CHECK` | `true` | - | This option will be parse bodies of SMTP errors. It will be helpful if SMTP server does not return an exact answer that the email does not exist. By default [this option is disabled](https://truemail-rb.org/truemail-gem/#/validations-layers?id=smtp-safe-check-disabled), available for SMTP validation only. |
 | `LOG_STDOUT` | `true`  | - | This option will be enable log all http requests to stdout. By default this option is disabled. |
 
@@ -72,7 +73,7 @@ Run Truemail server with command as in example below:
 VERIFIER_EMAIL=your_email@example.com ACCESS_TOKENS=a262d915-15bc-417c-afeb-842c63b54154 rackup
 
 # =>
-# Thin web server (v1.7.2 codename Bachmanity)
+# Thin web server (v1.8.0 codename Possessed Pickle)
 # Maximum connections set to 1024
 # Listening on localhost:9292, CTRL+C to stop
 ```
@@ -94,7 +95,7 @@ LOG_STDOUT=true \
 thin -R config.ru -a 0.0.0.0 -p 9292 -e production start
 
 # =>
-# Thin web server (v1.7.2 codename Bachmanity)
+# Thin web server (v1.8.0 codename Possessed Pickle)
 # Maximum connections set to 1024
 # Listening on localhost:9292, CTRL+C to stop
 # 127.0.0.1 - - [26/Feb/2020:16:41:13 +0200] "GET /?email=admin%40bestweb.com.ua HTTP/1.1" 200 - 0.9195

--- a/app/truemail_server/version.rb
+++ b/app/truemail_server/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TruemailServer
-  VERSION = '0.2.7'
+  VERSION = '0.2.8'
 end

--- a/config/system/command_line_params.rb
+++ b/config/system/command_line_params.rb
@@ -17,6 +17,7 @@ module System
     attribute :whitelist_validation, System::Types::Params::Bool.optional
     attribute :blacklisted_domains, System::Types::StringToArray.optional
     attribute :not_rfc_mx_lookup_flow, System::Types::Params::Bool.optional
+    attribute :smtp_fail_fast, System::Types::Params::Bool.optional
     attribute :smtp_safe_check, System::Types::Params::Bool.optional
     attribute :access_tokens, System::Types::StringToArray
     attribute :log_stdout, System::Types::Params::Bool.optional

--- a/config/system/configuration.rb
+++ b/config/system/configuration.rb
@@ -19,6 +19,7 @@ module System
       whitelist_validation
       blacklisted_domains
       not_rfc_mx_lookup_flow
+      smtp_fail_fast
       smtp_safe_check
       access_tokens
       log_stdout

--- a/spec/system/command_line_params_spec.rb
+++ b/spec/system/command_line_params_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe System::CommandLineParams do
           whitelist_validation: 'true',
           blacklisted_domains: '',
           not_rfc_mx_lookup_flow: 'false',
+          smtp_fail_fast: 'false',
           smtp_safe_check: 'false',
           access_tokens: '1,2',
           log_stdout: 'true'
@@ -58,6 +59,7 @@ RSpec.describe System::CommandLineParams do
           whitelist_validation: true,
           blacklisted_domains: [],
           not_rfc_mx_lookup_flow: false,
+          smtp_fail_fast: false,
           smtp_safe_check: false,
           access_tokens: %w[1 2],
           log_stdout: true


### PR DESCRIPTION
Added ability to use [SMTP fail fast flow](https://truemail-rb.org/truemail-gem/#/validations-layers?id=smtp-fail-fast-enabled), https://github.com/truemail-rb/truemail/pull/114:

- [x] Updated `System::CommandLineParams`
- [x] Updated `System::Configuration::COMMAND_LINE_ATTRS`
- [x] Updated application readme, version, changelog